### PR TITLE
Change default port to 8550

### DIFF
--- a/pglet/pglet.py
+++ b/pglet/pglet.py
@@ -61,7 +61,7 @@ def _connect_internal(name=None, is_app=False, web=False, server=None, token=Non
         server = HOSTED_SERVICE_URL
     elif server == None:
         env_port = os.getenv('PGLET_SERVER_PORT')
-        port = env_port if env_port != None and env_port != "" else "5000"
+        port = env_port if env_port != None and env_port != "" else "8550"
         server = f"http://localhost:{port}"
 
     connected = threading.Event()


### PR DESCRIPTION
In pglet/pglet#129, the default port for the pglet server was changed from `5000` to `8550`.
This PR updates the default port in the client library to match the new default port.