### PR TITLE
Support dicts as Grid items and some finessing

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -11,6 +11,12 @@ requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 summary = "Classes Without Boilerplate"
 
 [[package]]
+name = "beartype"
+version = "0.9.1"
+requires_python = ">=3.6.0"
+summary = "Unbearably fast runtime type checking in pure Python."
+
+[[package]]
 name = "colorama"
 version = "0.4.4"
 requires_python = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
@@ -104,7 +110,7 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 
 [metadata]
 lock_version = "3.1"
-content_hash = "sha256:db659cb66c51bc33388cfb9b2dc7a102173edf966cc91f9434cce3c83e8b0c3c"
+content_hash = "sha256:94218754ca77d26089db017ba8115b2eeac8a09dda9a14a6f4bfbceda92306b8"
 
 [metadata.files]
 "atomicwrites 1.4.0" = [
@@ -114,6 +120,10 @@ content_hash = "sha256:db659cb66c51bc33388cfb9b2dc7a102173edf966cc91f9434cce3c83
 "attrs 21.4.0" = [
     {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
     {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
+]
+"beartype 0.9.1" = [
+    {file = "beartype-0.9.1-py3-none-any.whl", hash = "sha256:fb23f59b709dd29c4bff25ede0969cdd76aa7e7812abef704d08007ea07372e0"},
+    {file = "beartype-0.9.1.tar.gz", hash = "sha256:623630dc243b0da5a84f0fa414e6aaaf2613e567ad19abfe6a81c17ea5ab62f1"},
 ]
 "colorama 0.4.4" = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},

--- a/pglet/grid.py
+++ b/pglet/grid.py
@@ -195,7 +195,7 @@ class Items(Control):
             return hash(tuple(self.__dict__.items()))
 
     def __init__(self, id=None, items=None):
-        Control.__init__(self, id=None)
+        Control.__init__(self, id=id)
     
         self.__map = {}
         self.__items = []

--- a/pglet/grid.py
+++ b/pglet/grid.py
@@ -69,8 +69,8 @@ class Column(Control):
         return self._get_attr("iconOnly")
 
     @icon_only.setter
-    def icon_only(self, value):
-        assert value == None or isinstance(value, bool), "iconOnly must be a boolean"
+    @beartype
+    def icon_only(self, value: Optional[bool]):
         self._set_attr("iconOnly", value)
 
     # field_name
@@ -115,8 +115,8 @@ class Column(Control):
         return self._get_attr("resizable")
 
     @resizable.setter
-    def resizable(self, value):
-        assert value == None or isinstance(value, bool), "resizable must be a boolean"
+    @beartype
+    def resizable(self, value: Optional[bool]):
         self._set_attr("resizable", value)
 
     # min_width
@@ -125,8 +125,8 @@ class Column(Control):
         return self._get_attr("minWidth")
 
     @min_width.setter
-    def min_width(self, value):
-        assert value == None or isinstance(value, int), "minWidth must be an int"
+    @beartype
+    def min_width(self, value: Optional[int]):
         self._set_attr("minWidth", value)
     
     
@@ -136,8 +136,8 @@ class Column(Control):
         return self._get_attr("maxWidth")
 
     @max_width.setter
-    def max_width(self, value):
-        assert value == None or isinstance(value, int), "maxWidth must be an int"
+    @beartype
+    def max_width(self, value: Optional[int]):  # could these not be floats? Union[None, int, float]
         self._set_attr("maxWidth", value)
 
     # on_click
@@ -146,8 +146,8 @@ class Column(Control):
         return self._get_attr("on_click")
 
     @on_click.setter
-    def on_click(self, value):
-        assert value == None or isinstance(value, bool), "resizable must be a boolean"
+    @beartype
+    def on_click(self, value: Optional[Callable]):
         self._set_attr("on_click", value)
 
     def _get_children(self):
@@ -360,8 +360,8 @@ class Grid(Control):
         return self._get_attr("compact")
 
     @compact.setter
-    def compact(self, value):
-        assert value == None or isinstance(value, bool), "compact must be a boolean"
+    @beartype
+    def compact(self, value: Optional[bool]):
         self._set_attr("compact", value)
 
     # header_visible
@@ -370,8 +370,8 @@ class Grid(Control):
         return self._get_attr("headerVisible")
 
     @header_visible.setter
-    def header_visible(self, value):
-        assert value == None or isinstance(value, bool), "header_visible must be a boolean"
+    @beartype
+    def header_visible(self, value: Optional[bool]):
         self._set_attr("headerVisible", value)
 
     # preserve_selection
@@ -380,8 +380,8 @@ class Grid(Control):
         return self._get_attr("preserveSelection")
 
     @preserve_selection.setter
-    def preserve_selection(self, value):
-        assert value == None or isinstance(value, bool), "preserve_selection must be a boolean"
+    @beartype
+    def preserve_selection(self, value: Optional[bool]):
         self._set_attr("preserveSelection", value)
 
     # shimmer_lines
@@ -390,8 +390,8 @@ class Grid(Control):
         return self._get_attr("shimmerLines")
 
     @shimmer_lines.setter
-    def shimmer_lines(self, value):
-        assert value == None or isinstance(value, int), "shimmerLines must be an int"
+    @beartype
+    def shimmer_lines(self, value: Optional[int]):
         self._set_attr("shimmerLines", value)
 
     def _on_select_internal(self, e):

--- a/pglet/grid.py
+++ b/pglet/grid.py
@@ -10,10 +10,22 @@ from pglet.control import Control
 
 # Column
 class Column(Control):
-    def __init__(self, id=None, name=None, icon=None, icon_only=None, 
-        field_name=None, sortable=None, sort_field=None, sorted=None, resizable=None,
-        min_width=None, max_width=None, on_click=None, template_controls=None,
-        new_window=None, expanded=None):
+    def __init__(
+        self,
+        id=None,
+        name=None,
+        icon=None,
+        icon_only=None,
+        field_name=None,
+        sortable=None,
+        sort_field=None,
+        sorted=None,
+        resizable=None,
+        min_width=None,
+        max_width=None,
+        on_click=None,
+        template_controls=None,
+    ):
         Control.__init__(self, id=id)
 
         self.name = name
@@ -230,15 +242,30 @@ class Items(Control):
         return items
 
 class Grid(Control):
-    def __init__(self, id=None, selection_mode=None, compact=None, header_visible=None, shimmer_lines=None,
-            preserve_selection=None,
-            columns=None, items=None, on_select=None, onitem_invoke=None,
-            width=None, height=None, padding=None, margin=None, visible=None, disabled=None):
-        
-        Control.__init__(self, id=id,
-            width=width, height=height, padding=padding, margin=margin,
-            visible=visible, disabled=disabled)
-        
+    def __init__(
+        self,
+        id=None,
+        selection_mode=None,
+        compact=None,
+        header_visible=None,
+        shimmer_lines=None,
+        preserve_selection=None,
+        columns=None,
+        items=None,
+        on_select=None,
+        onitem_invoke=None,
+        width=None,
+        height=None,
+        padding=None,
+        margin=None,
+        visible=None,
+        disabled=None,
+    ):
+
+        Control.__init__(
+            self, id=id, width=width, height=height, padding=padding, margin=margin, visible=visible, disabled=disabled
+        )
+
         self.selection_mode = selection_mode
         self.compact = compact
         self.header_visible = header_visible

--- a/pglet/grid.py
+++ b/pglet/grid.py
@@ -221,6 +221,10 @@ class Columns(Control):
 
 # Items
 class Items(Control):
+    class DictItem(SimpleNamespace):
+        def __hash__(self):
+            return hash(tuple(self.__dict__.items()))
+
     def __init__(self, id=None, items=None):
         Control.__init__(self, id=None)
     
@@ -237,7 +241,9 @@ class Items(Control):
 
     @items.setter
     def items(self, value):
-        self.__items = value
+        if isinstance(value, Sequence):
+            value = [Items.DictItem(**item) if isinstance(item, Mapping) else item for item in value]
+        self.__items = value or []
 
     def _get_control_name(self):
         return "items"

--- a/pglet/grid.py
+++ b/pglet/grid.py
@@ -1,4 +1,12 @@
+from types import SimpleNamespace
+from typing import Callable
+from typing import Mapping
+from typing import Optional
+from typing import Sequence
+
+from beartype import beartype
 from pglet.control import Control
+
 
 # Column
 class Column(Control):

--- a/pglet/protocol.py
+++ b/pglet/protocol.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass, field
 from typing import Dict, List
+from typing import Optional
+
 
 class Actions:
     REGISTER_HOST_CLIENT = "registerHostClient"
@@ -11,7 +13,7 @@ class Actions:
 @dataclass
 class Command:
     indent: int
-    name: str
+    name: Optional[str]
     values: List[str] = field(default_factory=list)
     attrs: Dict[str, str] = field(default_factory=dict)
     lines: List[str] = field(default_factory=list)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 ]
 dependencies = [
     "websocket-client>=1.2.1",
+    "beartype>=0.9.1",
 ]
 requires-python = ">=3.7"
 license = { text = "MIT" }

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,4 +1,6 @@
 import pglet
+import pytest
+from beartype.roar import BeartypeCallHintPepParamException
 from pglet import Grid, Column
 from pglet.protocol import Command
 
@@ -66,17 +68,67 @@ expected_result = [
 ]
 
 
-def test_grid_add():
-    g = Grid(selection_mode='multiple', compact=True, header_visible=True, shimmer_lines=1, columns=[
-        Column(field_name="first_name", name='First name', icon='mail', icon_only=True,
-        sortable='True', sort_field='sort field name', sorted='false', resizable=False, min_width=100, max_width=200),
-        Column(field_name="last_name", name='Last name')
-    ], items=[
-        Contact(first_name='Inesa', last_name='Fitsner'),
-        Contact(first_name='Fiodar', last_name='Fitsner')
-    ])
-
+def test_grid_add__with_class():
+    g = Grid(
+        selection_mode="multiple",
+        compact=True,
+        header_visible=True,
+        shimmer_lines=1,
+        columns=[
+            Column(
+                field_name="first_name",
+                name="First name",
+                icon="mail",
+                icon_only=True,
+                sortable="True",
+                sort_field="sort field name",
+                sorted="false",
+                resizable=False,
+                min_width=100,
+                max_width=200,
+            ),
+            Column(field_name="last_name", name="Last name"),
+        ],
+        items=[Contact(first_name="Inesa", last_name="Fitsner"), Contact(first_name="Fiodar", last_name="Fitsner")],
+    )
 
     assert isinstance(g, pglet.Control)
     assert isinstance(g, pglet.Grid)
     assert g.get_cmd_str() == expected_result, "Test failed"
+
+
+def test_grid_add__with_dict():
+    g = Grid(
+        selection_mode="multiple",
+        compact=True,
+        header_visible=True,
+        shimmer_lines=1,
+        columns=[
+            Column(
+                field_name="first_name",
+                name="First name",
+                icon="mail",
+                icon_only=True,
+                sortable="True",
+                sort_field="sort field name",
+                sorted="false",
+                resizable=False,
+                min_width=100,
+                max_width=200,
+            ),
+            Column(field_name="last_name", name="Last name"),
+        ],
+        items=[
+            {"first_name": "Inesa", "last_name": "Fitsner"},
+            {"first_name": "Fiodar", "last_name": "Fitsner"},
+        ],
+    )
+
+    assert isinstance(g, pglet.Control)
+    assert isinstance(g, pglet.Grid)
+    assert g.get_cmd_str() == expected_result, "Test failed"
+
+
+def test_property_value_check():
+    with pytest.raises(BeartypeCallHintPepParamException):
+        Column(icon_only="foo")

--- a/tests/test_grid.py
+++ b/tests/test_grid.py
@@ -1,10 +1,70 @@
 import pglet
 from pglet import Grid, Column
+from pglet.protocol import Command
+
 
 class Contact():
     def __init__(self, first_name, last_name):
         self.first_name = first_name
         self.last_name = last_name
+
+
+expected_result = [
+    Command(
+        indent=0,
+        name=None,
+        values=["grid"],
+        attrs={"compact": "true", "headervisible": "true", "selection": "multiple", "shimmerlines": "1"},
+        lines=[],
+        commands=[],
+    ),
+    Command(indent=2, name=None, values=["columns"], attrs={}, lines=[], commands=[]),
+    Command(
+        indent=4,
+        name=None,
+        values=["column"],
+        attrs={
+            "fieldname": "first_name",
+            "icon": "mail",
+            "icononly": "true",
+            "maxwidth": "200",
+            "minwidth": "100",
+            "name": "First name",
+            "resizable": "false",
+            "sortable": "True",
+            "sorted": "false",
+            "sortfield": "sort field name",
+        },
+        lines=[],
+        commands=[],
+    ),
+    Command(
+        indent=4,
+        name=None,
+        values=["column"],
+        attrs={"fieldname": "last_name", "name": "Last name"},
+        lines=[],
+        commands=[],
+    ),
+    Command(indent=2, name=None, values=["items"], attrs={}, lines=[], commands=[]),
+    Command(
+        indent=4,
+        name=None,
+        values=["item"],
+        attrs={"first_name": "Inesa", "last_name": "Fitsner"},
+        lines=[],
+        commands=[],
+    ),
+    Command(
+        indent=4,
+        name=None,
+        values=["item"],
+        attrs={"first_name": "Fiodar", "last_name": "Fitsner"},
+        lines=[],
+        commands=[],
+    ),
+]
+
 
 def test_grid_add():
     g = Grid(selection_mode='multiple', compact=True, header_visible=True, shimmer_lines=1, columns=[
@@ -19,12 +79,4 @@ def test_grid_add():
 
     assert isinstance(g, pglet.Control)
     assert isinstance(g, pglet.Grid)
-    assert g.get_cmd_str() == (
-        'grid compact="true" headervisible="true" selection="multiple" shimmerlines="1"\n'
-        '  columns\n'
-        '    column fieldname="first_name" icon="mail" icononly="true" maxwidth="200" minwidth="100" name="First name" resizable="false" sortable="True" sorted="false" sortfield="sort field name"\n'
-        '    column fieldname="last_name" name="Last name"\n'
-        '  items\n'
-        '    item first_name="Inesa" last_name="Fitsner"\n'
-        '    item first_name="Fiodar" last_name="Fitsner"'
-    ), "Test failed"
+    assert g.get_cmd_str() == expected_result, "Test failed"


### PR DESCRIPTION
This PR is intended more as a vehicle for discussion than something you might merge as-is (although does work as-is).

Only functionality changes are in these commits:
- Support dicts as items - Can provide dicts in the list of items given to the Grid control, i.e. works as long as the dicts have keys matching the expected columns
- Fix init call argument - Was accidentally always passing in None

Then there is a copy-paste update to tests to make them run with the new Commands.

For discussion:
- Non-functionality-impacting changes to make the code more "typical Python" and to use some of the built-in capabilities.
- Added `beartype` to have method name type hints checked automatically instead of manual asserts. Requirements say it is Python >= 3.6, but I saw something in docs about >= 3.9, so might need to check that before adopting, if you decide it looks useful.
- Used the `black` formatter on the code. Would highly recommend it to avoid any discussion and back-and-forth on styling. Also very nice to focus on the functionality and have the editor automatically reformat the code (I use `darker` with PyCharm, it has good instructions for other editors as well).