### PR TITLE
Border styling props in Stack, Text, Image and IFrame allow either single value or a list

### DIFF
--- a/examples/chat.py
+++ b/examples/chat.py
@@ -37,7 +37,7 @@ def main(page):
         rows=1,
         auto_adjust_height=True,
         shift_enter=True,
-        resizable=True,
+        resizable=False,
     )
 
     def on_message(user, message):

--- a/pglet/combobox.py
+++ b/pglet/combobox.py
@@ -1,14 +1,17 @@
-from typing import List, Optional
-try:
-    from typing import Literal
-except:
-    from typing_extensions import Literal
+from typing import List, Optional, Union
 
 from beartype import beartype
 
 from pglet.control import Control
 
+try:
+    from typing import Literal
+except:
+    from typing_extensions import Literal
+
+
 ItemType = Literal[None, "normal", "divider", "header", "selectAll", "select_all"]
+ComboBoxValue = Union[None, str, List[str]]
 
 
 class ComboBox(Control):
@@ -16,7 +19,7 @@ class ComboBox(Control):
         self,
         label=None,
         id=None,
-        value=None,
+        value: ComboBoxValue = None,
         placeholder=None,
         error_message=None,
         on_change=None,
@@ -95,16 +98,12 @@ class ComboBox(Control):
     # value
     @property
     def value(self):
-        v = self._get_attr("value")
-        if v and self.multi_select:
-            return [x.strip() for x in v.split(",")]
-        return v
+        return self._get_value_or_list_attr("value", ",")
 
     @value.setter
-    def value(self, value):
-        if isinstance(value, List):
-            value = ",".join(value)
-        self._set_attr("value", value)
+    @beartype
+    def value(self, value: ComboBoxValue):
+        self._set_value_or_list_attr("value", value, ",")
 
     # placeholder
     @property

--- a/pglet/control.py
+++ b/pglet/control.py
@@ -27,6 +27,9 @@ BorderStyles = Literal[
 ]
 
 BorderStyle = Union[None, BorderStyles, List[BorderStyles]]
+BorderWidth = Union[None, str, List[str]]
+BorderColor = Union[None, str, List[str]]
+BorderRadius = Union[None, str, List[str]]
 
 TextSize = Literal[
     None,
@@ -102,6 +105,17 @@ class Control:
 
     def _set_attr(self, name, value, dirty=True):
         self._set_attr_internal(name, value, dirty)
+
+    def _get_value_or_list_attr(self, name, delimiter):
+        v = self._get_attr(name)
+        if v and delimiter in v:
+            return [x.strip() for x in v.split(delimiter)]
+        return v
+
+    def _set_value_or_list_attr(self, name, value, delimiter):
+        if isinstance(value, List):
+            value = delimiter.join(value)
+        self._set_attr(name, value)
 
     def _set_attr_internal(self, name, value, dirty=True):
         name = name.lower()

--- a/pglet/iframe.py
+++ b/pglet/iframe.py
@@ -2,7 +2,7 @@ from typing import List
 
 from beartype import beartype
 
-from pglet.control import BorderStyle, Control
+from pglet.control import BorderColor, BorderRadius, BorderStyle, BorderWidth, Control
 
 
 class IFrame(Control):
@@ -11,9 +11,9 @@ class IFrame(Control):
         id=None,
         src=None,
         border_style: BorderStyle = None,
-        border_width=None,
-        border_color=None,
-        border_radius=None,
+        border_width: BorderWidth = None,
+        border_color: BorderColor = None,
+        border_radius: BorderRadius = None,
         title=None,
         width=None,
         height=None,
@@ -56,44 +56,42 @@ class IFrame(Control):
     # border_style
     @property
     def border_style(self):
-        v = self._get_attr("borderStyle")
-        if v:
-            return [x.strip() for x in v.split(" ")]
-        return v
+        return self._get_value_or_list_attr("borderStyle", " ")
 
     @border_style.setter
     @beartype
     def border_style(self, value: BorderStyle):
-        if isinstance(value, List):
-            value = " ".join(value)
-        self._set_attr("borderStyle", value)
+        self._set_value_or_list_attr("borderStyle", value, " ")
 
     # border_width
     @property
     def border_width(self):
-        return self._get_attr("borderWidth")
+        return self._get_value_or_list_attr("borderWidth", " ")
 
     @border_width.setter
-    def border_width(self, value):
-        self._set_attr("borderWidth", value)
+    @beartype
+    def border_width(self, value: BorderWidth):
+        self._set_value_or_list_attr("borderWidth", value, " ")
 
     # border_color
     @property
     def border_color(self):
-        return self._get_attr("borderColor")
+        return self._get_value_or_list_attr("borderColor", " ")
 
     @border_color.setter
-    def border_color(self, value):
-        self._set_attr("borderColor", value)
+    @beartype
+    def border_color(self, value: BorderColor):
+        self._set_value_or_list_attr("borderColor", value, " ")
 
     # border_radius
     @property
     def border_radius(self):
-        return self._get_attr("borderRadius")
+        return self._get_value_or_list_attr("borderRadius", " ")
 
     @border_radius.setter
-    def border_radius(self, value):
-        self._set_attr("borderRadius", value)
+    @beartype
+    def border_radius(self, value: BorderRadius):
+        self._set_value_or_list_attr("borderRadius", value, " ")
 
     # title
     @property

--- a/pglet/image.py
+++ b/pglet/image.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 
 from beartype import beartype
 
-from pglet.control import BorderStyle, Control
+from pglet.control import BorderColor, BorderRadius, BorderStyle, BorderWidth, Control
 
 try:
     from typing import Literal
@@ -25,9 +25,9 @@ class Image(Control):
         maximize_frame=None,
         fit: Fit = None,
         border_style: BorderStyle = None,
-        border_width=None,
-        border_color=None,
-        border_radius=None,
+        border_width: BorderWidth = None,
+        border_color: BorderColor = None,
+        border_radius: BorderRadius = None,
         width=None,
         height=None,
         padding=None,
@@ -110,41 +110,39 @@ class Image(Control):
     # border_style
     @property
     def border_style(self):
-        v = self._get_attr("borderStyle")
-        if v:
-            return [x.strip() for x in v.split(" ")]
-        return v
+        return self._get_value_or_list_attr("borderStyle", " ")
 
     @border_style.setter
     @beartype
     def border_style(self, value: BorderStyle):
-        if isinstance(value, List):
-            value = " ".join(value)
-        self._set_attr("borderStyle", value)
+        self._set_value_or_list_attr("borderStyle", value, " ")
 
     # border_width
     @property
     def border_width(self):
-        return self._get_attr("borderWidth")
+        return self._get_value_or_list_attr("borderWidth", " ")
 
     @border_width.setter
-    def border_width(self, value):
-        self._set_attr("borderWidth", value)
+    @beartype
+    def border_width(self, value: BorderWidth):
+        self._set_value_or_list_attr("borderWidth", value, " ")
 
     # border_color
     @property
     def border_color(self):
-        return self._get_attr("borderColor")
+        return self._get_value_or_list_attr("borderColor", " ")
 
     @border_color.setter
-    def border_color(self, value):
-        self._set_attr("borderColor", value)
+    @beartype
+    def border_color(self, value: BorderColor):
+        self._set_value_or_list_attr("borderColor", value, " ")
 
     # border_radius
     @property
     def border_radius(self):
-        return self._get_attr("borderRadius")
+        return self._get_value_or_list_attr("borderRadius", " ")
 
     @border_radius.setter
-    def border_radius(self, value):
-        self._set_attr("borderRadius", value)
+    @beartype
+    def border_radius(self, value: BorderRadius):
+        self._set_value_or_list_attr("borderRadius", value, " ")

--- a/pglet/stack.py
+++ b/pglet/stack.py
@@ -2,7 +2,7 @@ from typing import List, Optional
 
 from beartype import beartype
 
-from pglet.control import BorderStyle, Control
+from pglet.control import BorderColor, BorderRadius, BorderStyle, BorderWidth, Control
 
 try:
     from typing import Literal
@@ -40,9 +40,9 @@ class Stack(Control):
         wrap=None,
         bgcolor=None,
         border_style: BorderStyle = None,
-        border_width=None,
-        border_color=None,
-        border_radius=None,
+        border_width: BorderWidth = None,
+        border_color: BorderColor = None,
+        border_radius: BorderRadius = None,
         scroll_x=None,
         scroll_y=None,
         auto_scroll=None,
@@ -215,44 +215,42 @@ class Stack(Control):
     # border_style
     @property
     def border_style(self):
-        v = self._get_attr("borderStyle")
-        if v:
-            return [x.strip() for x in v.split(" ")]
-        return v
+        return self._get_value_or_list_attr("borderStyle", " ")
 
     @border_style.setter
     @beartype
     def border_style(self, value: BorderStyle):
-        if isinstance(value, List):
-            value = " ".join(value)
-        self._set_attr("borderStyle", value)
+        self._set_value_or_list_attr("borderStyle", value, " ")
 
     # border_width
     @property
     def border_width(self):
-        return self._get_attr("borderWidth")
+        return self._get_value_or_list_attr("borderWidth", " ")
 
     @border_width.setter
-    def border_width(self, value):
-        self._set_attr("borderWidth", value)
+    @beartype
+    def border_width(self, value: BorderWidth):
+        self._set_value_or_list_attr("borderWidth", value, " ")
 
     # border_color
     @property
     def border_color(self):
-        return self._get_attr("borderColor")
+        return self._get_value_or_list_attr("borderColor", " ")
 
     @border_color.setter
-    def border_color(self, value):
-        self._set_attr("borderColor", value)
+    @beartype
+    def border_color(self, value: BorderColor):
+        self._set_value_or_list_attr("borderColor", value, " ")
 
     # border_radius
     @property
     def border_radius(self):
-        return self._get_attr("borderRadius")
+        return self._get_value_or_list_attr("borderRadius", " ")
 
     @border_radius.setter
-    def border_radius(self, value):
-        self._set_attr("borderRadius", value)
+    @beartype
+    def border_radius(self, value: BorderRadius):
+        self._set_value_or_list_attr("borderRadius", value, " ")
 
     # scroll_x
     @property

--- a/pglet/text.py
+++ b/pglet/text.py
@@ -2,7 +2,15 @@ from typing import List, Optional
 
 from beartype import beartype
 
-from pglet.control import BorderStyle, Control, TextAlign, TextSize
+from pglet.control import (
+    BorderColor,
+    BorderRadius,
+    BorderStyle,
+    BorderWidth,
+    Control,
+    TextAlign,
+    TextSize,
+)
 
 try:
     from typing import Literal
@@ -30,9 +38,9 @@ class Text(Control):
         color=None,
         bgcolor=None,
         border_style: BorderStyle = None,
-        border_width=None,
-        border_color=None,
-        border_radius=None,
+        border_width: BorderWidth = None,
+        border_color: BorderColor = None,
+        border_radius: BorderRadius = None,
         width=None,
         height=None,
         padding=None,
@@ -192,41 +200,39 @@ class Text(Control):
     # border_style
     @property
     def border_style(self):
-        v = self._get_attr("borderStyle")
-        if v:
-            return [x.strip() for x in v.split(" ")]
-        return v
+        return self._get_value_or_list_attr("borderStyle", " ")
 
     @border_style.setter
     @beartype
     def border_style(self, value: BorderStyle):
-        if isinstance(value, List):
-            value = " ".join(value)
-        self._set_attr("borderStyle", value)
+        self._set_value_or_list_attr("borderStyle", value, " ")
 
     # border_width
     @property
     def border_width(self):
-        return self._get_attr("borderWidth")
+        return self._get_value_or_list_attr("borderWidth", " ")
 
     @border_width.setter
-    def border_width(self, value):
-        self._set_attr("borderWidth", value)
+    @beartype
+    def border_width(self, value: BorderWidth):
+        self._set_value_or_list_attr("borderWidth", value, " ")
 
     # border_color
     @property
     def border_color(self):
-        return self._get_attr("borderColor")
+        return self._get_value_or_list_attr("borderColor", " ")
 
     @border_color.setter
-    def border_color(self, value):
-        self._set_attr("borderColor", value)
+    @beartype
+    def border_color(self, value: BorderColor):
+        self._set_value_or_list_attr("borderColor", value, " ")
 
     # border_radius
     @property
     def border_radius(self):
-        return self._get_attr("borderRadius")
+        return self._get_value_or_list_attr("borderRadius", " ")
 
     @border_radius.setter
-    def border_radius(self, value):
-        self._set_attr("borderRadius", value)
+    @beartype
+    def border_radius(self, value: BorderRadius):
+        self._set_value_or_list_attr("borderRadius", value, " ")

--- a/tests/test_iframe.py
+++ b/tests/test_iframe.py
@@ -27,7 +27,7 @@ def test_iframe_multiple_border_styles():
     assert isinstance(c, pglet.Control)
     assert isinstance(c, pglet.IFrame)
 
-    # check property reading
+    # check property reading as a list
     style = c.border_style
     assert isinstance(style, List)
     assert len(style) == 3
@@ -42,3 +42,79 @@ def test_iframe_multiple_border_styles():
             commands=[],
         )
     ], "Test failed"
+
+
+def test_iframe_border_style():
+    # list of values
+    c = IFrame(border_style=["solid", "dashed"])
+    v = c.border_style
+    assert isinstance(v, List)
+    assert len(v) == 2
+
+    # single value
+    c.border_style = "groove"
+    v = c.border_style
+    assert isinstance(v, str)
+    assert v == "groove"
+
+    # none
+    c.border_style = None
+    v = c.border_style
+    assert v == ""
+
+
+def test_iframe_border_color():
+    # list of values
+    c = IFrame(border_color=["red", "yellow"])
+    v = c.border_color
+    assert isinstance(v, List)
+    assert len(v) == 2
+
+    # single value
+    c.border_color = "blue"
+    v = c.border_color
+    assert isinstance(v, str)
+    assert v == "blue"
+
+    # none
+    c.border_color = None
+    v = c.border_color
+    assert v == ""
+
+
+def test_iframe_border_width():
+    # list of values
+    c = IFrame(border_width=["1px", "2px", "1", "2"])
+    v = c.border_width
+    assert isinstance(v, List)
+    assert len(v) == 4
+
+    # single value
+    c.border_width = "10"
+    v = c.border_width
+    assert isinstance(v, str)
+    assert v == "10"
+
+    # none
+    c.border_width = None
+    v = c.border_width
+    assert v == ""
+
+
+def test_iframe_border_radius():
+    # list of values
+    c = IFrame(border_radius=["1px", "2px", "1", "2"])
+    v = c.border_radius
+    assert isinstance(v, List)
+    assert len(v) == 4
+
+    # single value
+    c.border_radius = "10"
+    v = c.border_radius
+    assert isinstance(v, str)
+    assert v == "10"
+
+    # none
+    c.border_radius = None
+    v = c.border_radius
+    assert v == ""


### PR DESCRIPTION
Border styling props in `Stack`, `Text`, `Image` and `IFrame` allow either single value or a list

* `border_style`
* `border_color`
* `border_width`
* `border_radius`

For example:

```python
stack.border_style = "solid" # all sides have a solid border
stack.border_style = ["solid", "dashed"] # top and bottom are solid; left and right - dashed
stack.border_style = ["none", "none", "solid", "none"] # only bottom border is solid
```