### PR TITLE
Control Refs

### DIFF
--- a/examples/chat-ref.py
+++ b/examples/chat-ref.py
@@ -1,0 +1,103 @@
+# import logging
+
+import pglet
+from pglet import Button, Dialog, Stack, Text, Textbox
+from pglet.ref import Ref
+
+# logging.basicConfig(level=logging.DEBUG)
+
+pub_sub = {}
+
+
+def broadcast(user, message):
+    for session_id, handler in pub_sub.items():
+        handler(user, message)
+
+
+def main(page):
+
+    page.padding = 10
+    page.vertical_fill = True
+    page.title = "Pglet Chat Example"
+    page.bgcolor = "neutralLight"
+    page.theme = "light"  # "dark"
+
+    username_dialog = Ref[Dialog]()
+    username = Ref[Textbox]()
+    messages = Ref[Stack]()
+    message = Ref[Textbox]()
+
+    def on_message(user, message):
+        if user:
+            messages.current.controls.append(Text(f"{user}: {message}"))
+        else:
+            messages.current.controls.append(
+                Text(message, color="#888", size="small", italic=True)
+            )
+        page.update()
+
+    pub_sub[page.session_id] = on_message
+
+    def send_click(e):
+        if message.current.value == "":
+            return
+        broadcast(page.user, message.current.value)
+        message.current.value = ""
+        page.update()
+
+    page.user = page.session_id
+
+    def join_click(e):
+        if username.current.value == "":
+            username.current.error_message = "Name cannot be blank!"
+            username.current.update()
+        else:
+            page.user = username.current.value
+            username_dialog.current.open = False
+            # user_name.focused = False
+            message.current.prefix = f"{page.user}:"
+            message.current.focused = True
+            page.update()
+            broadcast(None, f"{page.user} entered the chat!")
+
+    # layout
+    page.add(
+        Stack(
+            height="100%",
+            width="100%",
+            bgcolor="white",
+            padding=10,
+            border_radius=5,
+            vertical_align="end",
+            controls=[Stack(ref=messages, scroll_y=True, auto_scroll=True)],
+        ),
+        Stack(
+            horizontal=True,
+            width="100%",
+            controls=[
+                Textbox(
+                    ref=message,
+                    width="100%",
+                    multiline=True,
+                    rows=1,
+                    auto_adjust_height=True,
+                    shift_enter=True,
+                    resizable=False,
+                ),
+                Button("Send", primary=True, on_click=send_click),
+            ],
+            on_submit=send_click,
+        ),
+        Dialog(
+            ref=username_dialog,
+            open=True,
+            blocking=True,
+            auto_dismiss=False,
+            title="Welcome!",
+            controls=[Textbox(ref=username, label="Enter your name", focused=True)],
+            footer=[Button(text="Join chat", primary=True, on_click=join_click)],
+        ),
+    )
+
+
+pglet.app("chat", target=main, web=False)

--- a/pglet/__init__.py
+++ b/pglet/__init__.py
@@ -24,6 +24,7 @@ from pglet.pglet import *
 from pglet.piechart import PieChart
 from pglet.progress import Progress
 from pglet.reconnecting_websocket import *
+from pglet.ref import Ref
 from pglet.searchbox import SearchBox
 from pglet.slider import Slider
 from pglet.spinbutton import SpinButton

--- a/pglet/barchart.py
+++ b/pglet/barchart.py
@@ -17,6 +17,7 @@ class BarChart(Control):
     def __init__(
         self,
         id=None,
+        ref=None,
         tooltips=None,
         data_mode: DataMode = None,
         points=None,
@@ -31,6 +32,7 @@ class BarChart(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,
@@ -80,8 +82,8 @@ class BarChart(Control):
 
 
 class Data(Control):
-    def __init__(self, id=None, points=None):
-        Control.__init__(self, id=id)
+    def __init__(self, id=None, ref=None, points=None):
+        Control.__init__(self, id=id, ref=ref)
 
         self.__points = []
         if points != None:
@@ -108,6 +110,7 @@ class Point(Control):
     def __init__(
         self,
         id=None,
+        ref=None,
         x=None,
         y=None,
         legend=None,
@@ -115,7 +118,7 @@ class Point(Control):
         x_tooltip=None,
         y_tooltip=None,
     ):
-        Control.__init__(self, id=id)
+        Control.__init__(self, id=id, ref=ref)
 
         self.x = x
         self.y = y

--- a/pglet/button.py
+++ b/pglet/button.py
@@ -10,6 +10,7 @@ class Button(Control):
         self,
         text=None,
         id=None,
+        ref=None,
         primary=None,
         compound=None,
         action=None,
@@ -37,6 +38,7 @@ class Button(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,
@@ -239,6 +241,7 @@ class MenuItem(Control):
         self,
         text=None,
         id=None,
+        ref=None,
         secondary_text=None,
         url=None,
         new_window=None,
@@ -260,6 +263,7 @@ class MenuItem(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,

--- a/pglet/callout.py
+++ b/pglet/callout.py
@@ -33,6 +33,7 @@ class Callout(Control):
     def __init__(
         self,
         id=None,
+        ref=None,
         target=None,
         position: Position = None,
         gap=None,
@@ -54,6 +55,7 @@ class Callout(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,

--- a/pglet/checkbox.py
+++ b/pglet/checkbox.py
@@ -18,6 +18,7 @@ class Checkbox(Control):
         self,
         label=None,
         id=None,
+        ref=None,
         value=None,
         value_field=None,
         box_side: BoxSide = None,
@@ -34,6 +35,7 @@ class Checkbox(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,

--- a/pglet/choicegroup.py
+++ b/pglet/choicegroup.py
@@ -120,7 +120,7 @@ class ChoiceGroup(Control):
 
 
 class Option(Control):
-    def __init__(self, ref=None, key=None, text=None, icon=None, icon_color=None):
+    def __init__(self, key=None, text=None, icon=None, icon_color=None, ref=None):
         Control.__init__(self, ref=ref)
         assert key != None or text != None, "key or text must be specified"
 

--- a/pglet/choicegroup.py
+++ b/pglet/choicegroup.py
@@ -10,6 +10,7 @@ class ChoiceGroup(Control):
         self,
         label=None,
         id=None,
+        ref=None,
         value=None,
         data=None,
         options=None,
@@ -27,6 +28,7 @@ class ChoiceGroup(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,
@@ -118,8 +120,8 @@ class ChoiceGroup(Control):
 
 
 class Option(Control):
-    def __init__(self, key=None, text=None, icon=None, icon_color=None):
-        Control.__init__(self)
+    def __init__(self, ref=None, key=None, text=None, icon=None, icon_color=None):
+        Control.__init__(self, ref=ref)
         assert key != None or text != None, "key or text must be specified"
 
         self.key = key

--- a/pglet/combobox.py
+++ b/pglet/combobox.py
@@ -189,7 +189,7 @@ class ComboBox(Control):
 
 class Option(Control):
     def __init__(
-        self, ref=None, key=None, text=None, item_type: ItemType = None, disabled=None
+        self, key=None, text=None, item_type: ItemType = None, disabled=None, ref=None
     ):
         Control.__init__(self, ref=ref, disabled=disabled)
         assert key != None or text != None, "key or text must be specified"

--- a/pglet/combobox.py
+++ b/pglet/combobox.py
@@ -19,6 +19,7 @@ class ComboBox(Control):
         self,
         label=None,
         id=None,
+        ref=None,
         value: ComboBoxValue = None,
         placeholder=None,
         error_message=None,
@@ -41,6 +42,7 @@ class ComboBox(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,
@@ -186,8 +188,10 @@ class ComboBox(Control):
 
 
 class Option(Control):
-    def __init__(self, key=None, text=None, item_type: ItemType = None, disabled=None):
-        Control.__init__(self, disabled=disabled)
+    def __init__(
+        self, ref=None, key=None, text=None, item_type: ItemType = None, disabled=None
+    ):
+        Control.__init__(self, ref=ref, disabled=disabled)
         assert key != None or text != None, "key or text must be specified"
         self.key = key
         self.text = text

--- a/pglet/control.py
+++ b/pglet/control.py
@@ -6,6 +6,7 @@ from typing import List, Optional, Union
 from beartype import beartype
 
 from pglet.protocol import Command
+from pglet.ref import Ref
 
 try:
     from typing import Literal
@@ -27,9 +28,9 @@ BorderStyles = Literal[
 ]
 
 BorderStyle = Union[None, BorderStyles, List[BorderStyles]]
-BorderWidth = Union[None, str, List[str]]
+BorderWidth = Union[None, str, int, float, List[str], List[int], List[float]]
 BorderColor = Union[None, str, List[str]]
-BorderRadius = Union[None, str, List[str]]
+BorderRadius = Union[None, str, int, float, List[str], List[int], List[float]]
 
 TextSize = Literal[
     None,
@@ -53,6 +54,7 @@ class Control:
     def __init__(
         self,
         id=None,
+        ref: Ref = None,
         width=None,
         height=None,
         padding=None,
@@ -77,6 +79,11 @@ class Control:
         self.data = data
         self.__event_handlers = {}
         self._lock = threading.Lock()
+        if ref:
+            ref.current = self
+
+    def _assign(self, variable):
+        variable = self
 
     def _get_children(self):
         return []
@@ -114,7 +121,7 @@ class Control:
 
     def _set_value_or_list_attr(self, name, value, delimiter):
         if isinstance(value, List):
-            value = delimiter.join(value)
+            value = delimiter.join([str(x) for x in value])
         self._set_attr(name, value)
 
     def _set_attr_internal(self, name, value, dirty=True):

--- a/pglet/datepicker.py
+++ b/pglet/datepicker.py
@@ -11,6 +11,7 @@ class DatePicker(Control):
         self,
         label=None,
         id=None,
+        ref=None,
         value=None,
         placeholder=None,
         required=None,
@@ -25,7 +26,9 @@ class DatePicker(Control):
         visible=None,
         disabled=None,
     ):
-        Control.__init__(self, id=id, width=width, visible=visible, disabled=disabled)
+        Control.__init__(
+            self, id=id, ref=ref, width=width, visible=visible, disabled=disabled
+        )
         self.label = label
         self.value = value
         self.placeholder = placeholder

--- a/pglet/dialog.py
+++ b/pglet/dialog.py
@@ -17,6 +17,7 @@ class Dialog(Control):
     def __init__(
         self,
         id=None,
+        ref=None,
         open=None,
         title=None,
         sub_text=None,
@@ -40,6 +41,7 @@ class Dialog(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,
@@ -177,8 +179,8 @@ class Dialog(Control):
 
 
 class Footer(Control):
-    def __init__(self, id=None, controls=None):
-        Control.__init__(self, id=id)
+    def __init__(self, id=None, ref=None, controls=None):
+        Control.__init__(self, id=id, ref=ref)
 
         self.__controls = []
         if controls != None:

--- a/pglet/dropdown.py
+++ b/pglet/dropdown.py
@@ -18,6 +18,7 @@ class Dropdown(Control):
         self,
         label=None,
         id=None,
+        ref=None,
         value=None,
         placeholder=None,
         error_message=None,
@@ -37,6 +38,7 @@ class Dropdown(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,
@@ -148,8 +150,10 @@ class Dropdown(Control):
 
 
 class Option(Control):
-    def __init__(self, key=None, text=None, item_type: ItemType = None, disabled=None):
-        Control.__init__(self, disabled=disabled)
+    def __init__(
+        self, ref=None, key=None, text=None, item_type: ItemType = None, disabled=None
+    ):
+        Control.__init__(self, ref=ref, disabled=disabled)
         assert key != None or text != None, "key or text must be specified"
         self.key = key
         self.text = text

--- a/pglet/dropdown.py
+++ b/pglet/dropdown.py
@@ -151,7 +151,7 @@ class Dropdown(Control):
 
 class Option(Control):
     def __init__(
-        self, ref=None, key=None, text=None, item_type: ItemType = None, disabled=None
+        self, key=None, text=None, item_type: ItemType = None, disabled=None, ref=None
     ):
         Control.__init__(self, ref=ref, disabled=disabled)
         assert key != None or text != None, "key or text must be specified"

--- a/pglet/grid.py
+++ b/pglet/grid.py
@@ -21,6 +21,7 @@ class Grid(Control):
     def __init__(
         self,
         id=None,
+        ref=None,
         selection_mode: SelectionMode = None,
         compact=None,
         header_visible=None,
@@ -40,6 +41,7 @@ class Grid(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,
@@ -177,8 +179,8 @@ class Grid(Control):
 
 
 class Columns(Control):
-    def __init__(self, id=None, columns=None):
-        Control.__init__(self, id=id)
+    def __init__(self, id=None, ref=None, columns=None):
+        Control.__init__(self, id=id, ref=ref)
 
         self.columns = columns
 
@@ -190,8 +192,8 @@ class Columns(Control):
 
 
 class Items(Control):
-    def __init__(self, id=None, items=None):
-        Control.__init__(self, id=id)
+    def __init__(self, id=None, ref=None, items=None):
+        Control.__init__(self, id=id, ref=ref)
 
         self.__map = {}
         self.__items = []
@@ -231,6 +233,7 @@ class Column(Control):
     def __init__(
         self,
         id=None,
+        ref=None,
         name=None,
         icon=None,
         icon_only=None,
@@ -244,7 +247,7 @@ class Column(Control):
         on_click=None,
         template_controls=None,
     ):
-        Control.__init__(self, id=id)
+        Control.__init__(self, id=id, ref=ref)
 
         self.name = name
         self.icon = icon

--- a/pglet/html.py
+++ b/pglet/html.py
@@ -2,9 +2,9 @@ from pglet.control import Control
 
 
 class Html(Control):
-    def __init__(self, value=None, id=None, visible=None):
+    def __init__(self, value=None, id=None, ref=None, visible=None):
 
-        Control.__init__(self, id=id, visible=visible)
+        Control.__init__(self, id=id, ref=ref, visible=visible)
 
         self.value = value
 

--- a/pglet/icon.py
+++ b/pglet/icon.py
@@ -6,6 +6,7 @@ class Icon(Control):
         self,
         name=None,
         id=None,
+        ref=None,
         color=None,
         size=None,
         width=None,
@@ -19,6 +20,7 @@ class Icon(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,

--- a/pglet/iframe.py
+++ b/pglet/iframe.py
@@ -9,6 +9,7 @@ class IFrame(Control):
     def __init__(
         self,
         id=None,
+        ref=None,
         src=None,
         border_style: BorderStyle = None,
         border_width: BorderWidth = None,
@@ -26,6 +27,7 @@ class IFrame(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,

--- a/pglet/image.py
+++ b/pglet/image.py
@@ -20,6 +20,7 @@ class Image(Control):
         self,
         src=None,
         id=None,
+        ref=None,
         alt=None,
         title=None,
         maximize_frame=None,
@@ -39,6 +40,7 @@ class Image(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,

--- a/pglet/linechart.py
+++ b/pglet/linechart.py
@@ -17,6 +17,7 @@ class LineChart(Control):
     def __init__(
         self,
         id=None,
+        ref=None,
         legend=None,
         tooltips=None,
         stroke_width=None,
@@ -37,6 +38,7 @@ class LineChart(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,
@@ -155,8 +157,8 @@ class LineChart(Control):
 
 
 class Data(Control):
-    def __init__(self, id=None, color=None, legend=None, points=None):
-        Control.__init__(self, id=id)
+    def __init__(self, id=None, ref=None, color=None, legend=None, points=None):
+        Control.__init__(self, id=id, ref=ref)
 
         self.color = color
         self.legend = legend
@@ -203,6 +205,7 @@ class Point(Control):
     def __init__(
         self,
         id=None,
+        ref=None,
         x=None,
         y=None,
         tick=None,
@@ -210,7 +213,7 @@ class Point(Control):
         x_tooltip=None,
         y_tooltip=None,
     ):
-        Control.__init__(self, id=id)
+        Control.__init__(self, id=id, ref=ref)
 
         self.x = x
         self.y = y

--- a/pglet/link.py
+++ b/pglet/link.py
@@ -10,6 +10,7 @@ class Link(Control):
         self,
         url=None,
         id=None,
+        ref=None,
         value=None,
         new_window=None,
         title=None,
@@ -32,6 +33,7 @@ class Link(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,

--- a/pglet/message.py
+++ b/pglet/message.py
@@ -21,6 +21,7 @@ class Message(Control):
         value=None,
         type: MessageType = None,
         id=None,
+        ref=None,
         multiline=None,
         truncated=None,
         dismiss=None,
@@ -38,6 +39,7 @@ class Message(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,

--- a/pglet/nav.py
+++ b/pglet/nav.py
@@ -9,6 +9,7 @@ class Nav(Control):
     def __init__(
         self,
         id=None,
+        ref=None,
         value=None,
         items=None,
         on_change=None,
@@ -25,6 +26,7 @@ class Nav(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,
@@ -98,6 +100,7 @@ class Item(Control):
     def __init__(
         self,
         id=None,
+        ref=None,
         key=None,
         text=None,
         icon=None,
@@ -110,7 +113,9 @@ class Item(Control):
         disabled=None,
         data=None,
     ):
-        Control.__init__(self, id=id, visible=visible, disabled=disabled, data=data)
+        Control.__init__(
+            self, id=id, ref=ref, visible=visible, disabled=disabled, data=data
+        )
         # key and text are optional for group item but key or text are required for level 2 and deeper items
         # assert key != None or text != None, "key or text must be specified"
         self.key = key

--- a/pglet/panel.py
+++ b/pglet/panel.py
@@ -28,6 +28,7 @@ class Panel(Control):
     def __init__(
         self,
         id=None,
+        ref=None,
         open=None,
         title=None,
         type: PanelType = None,
@@ -49,6 +50,7 @@ class Panel(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,
@@ -176,8 +178,8 @@ class Panel(Control):
 
 
 class Footer(Control):
-    def __init__(self, id=None, controls=None):
-        Control.__init__(self, id=id)
+    def __init__(self, id=None, ref=None, controls=None):
+        Control.__init__(self, id=id, ref=ref)
 
         self.__controls = []
         if controls != None:

--- a/pglet/persona.py
+++ b/pglet/persona.py
@@ -46,6 +46,7 @@ class Persona(Control):
         self,
         text=None,
         id=None,
+        ref=None,
         image_url=None,
         image_alt=None,
         initials_color: InitialsColor = None,
@@ -59,7 +60,7 @@ class Persona(Control):
         visible=None,
     ):
 
-        Control.__init__(self, id=id, visible=visible)
+        Control.__init__(self, id=id, ref=ref, visible=visible)
 
         self.text = text
         self.image_url = image_url

--- a/pglet/piechart.py
+++ b/pglet/piechart.py
@@ -9,6 +9,7 @@ class PieChart(Control):
     def __init__(
         self,
         id=None,
+        ref=None,
         legend=None,
         tooltips=None,
         inner_value=None,
@@ -25,6 +26,7 @@ class PieChart(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,
@@ -95,8 +97,8 @@ class PieChart(Control):
 
 
 class Data(Control):
-    def __init__(self, id=None, points=None):
-        Control.__init__(self, id=id)
+    def __init__(self, id=None, ref=None, points=None):
+        Control.__init__(self, id=id, ref=ref)
 
         self.__points = []
         if points != None:
@@ -120,8 +122,10 @@ class Data(Control):
 
 
 class Point(Control):
-    def __init__(self, id=None, value=None, legend=None, color=None, tooltip=None):
-        Control.__init__(self, id=id)
+    def __init__(
+        self, id=None, ref=None, value=None, legend=None, color=None, tooltip=None
+    ):
+        Control.__init__(self, id=id, ref=ref)
 
         self.value = value
         self.legend = legend

--- a/pglet/progress.py
+++ b/pglet/progress.py
@@ -1,5 +1,7 @@
 from typing import Optional
+
 from beartype import beartype
+
 from pglet.control import Control
 
 
@@ -8,6 +10,7 @@ class Progress(Control):
         self,
         label=None,
         id=None,
+        ref=None,
         description=None,
         value=None,
         bar_height=None,
@@ -21,6 +24,7 @@ class Progress(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,

--- a/pglet/ref.py
+++ b/pglet/ref.py
@@ -1,0 +1,16 @@
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class Ref(Generic[T]):
+    def __init__(self):
+        self._current: T = None
+
+    @property
+    def current(self) -> T:
+        return self._current
+
+    @current.setter
+    def current(self, value: T):
+        self._current = value

--- a/pglet/searchbox.py
+++ b/pglet/searchbox.py
@@ -9,6 +9,7 @@ class SearchBox(Control):
     def __init__(
         self,
         id=None,
+        ref=None,
         value=None,
         placeholder=None,
         underlined=None,
@@ -32,6 +33,7 @@ class SearchBox(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,

--- a/pglet/slider.py
+++ b/pglet/slider.py
@@ -10,6 +10,7 @@ class Slider(Control):
         self,
         label=None,
         id=None,
+        ref=None,
         value=None,
         min=None,
         max=None,
@@ -32,6 +33,7 @@ class Slider(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,

--- a/pglet/spinbutton.py
+++ b/pglet/spinbutton.py
@@ -18,6 +18,7 @@ class SpinButton(Control):
         self,
         label=None,
         id=None,
+        ref=None,
         value=None,
         min=None,
         max=None,
@@ -39,6 +40,7 @@ class SpinButton(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,

--- a/pglet/spinner.py
+++ b/pglet/spinner.py
@@ -1,11 +1,12 @@
+from beartype._decor.main import beartype
+
+from pglet.control import Control
+
 try:
     from typing import Literal
 except:
     from typing_extensions import Literal
 
-from beartype._decor.main import beartype
-
-from pglet.control import Control
 
 Position = Literal[None, "left", "top", "right", "bottom"]
 
@@ -15,6 +16,7 @@ class Spinner(Control):
         self,
         label=None,
         id=None,
+        ref=None,
         label_position: Position = None,
         size=None,
         width=None,
@@ -27,6 +29,7 @@ class Spinner(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,

--- a/pglet/splitstack.py
+++ b/pglet/splitstack.py
@@ -15,6 +15,7 @@ class SplitStack(Control):
         self,
         controls=None,
         id=None,
+        ref=None,
         horizontal=None,
         gutter_size=None,
         gutter_color=None,
@@ -30,6 +31,7 @@ class SplitStack(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             visible=visible,

--- a/pglet/stack.py
+++ b/pglet/stack.py
@@ -28,6 +28,7 @@ class Stack(Control):
         self,
         controls=None,
         id=None,
+        ref=None,
         horizontal=None,
         vertical_fill=None,
         horizontal_align: Align = None,
@@ -58,6 +59,7 @@ class Stack(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,

--- a/pglet/tabs.py
+++ b/pglet/tabs.py
@@ -10,6 +10,7 @@ class Tabs(Control):
         self,
         tabs=None,
         id=None,
+        ref=None,
         value=None,
         solid=None,
         on_change=None,
@@ -24,6 +25,7 @@ class Tabs(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,
@@ -100,8 +102,10 @@ class Tabs(Control):
 
 
 class Tab(Control):
-    def __init__(self, text, controls=None, id=None, key=None, icon=None, count=None):
-        Control.__init__(self, id=id)
+    def __init__(
+        self, text, controls=None, id=None, ref=None, key=None, icon=None, count=None
+    ):
+        Control.__init__(self, id=id, ref=ref)
         assert key or text, "key or text must be specified"
         self.key = key
         self.text = text

--- a/pglet/text.py
+++ b/pglet/text.py
@@ -26,6 +26,7 @@ class Text(Control):
         self,
         value=None,
         id=None,
+        ref=None,
         markdown=None,
         align: TextAlign = None,
         vertical_align: VerticalAlign = None,
@@ -52,6 +53,7 @@ class Text(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,

--- a/pglet/textbox.py
+++ b/pglet/textbox.py
@@ -10,6 +10,7 @@ class Textbox(Control):
         self,
         label=None,
         id=None,
+        ref=None,
         value=None,
         placeholder=None,
         error_message=None,
@@ -43,6 +44,7 @@ class Textbox(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,

--- a/pglet/toggle.py
+++ b/pglet/toggle.py
@@ -10,6 +10,7 @@ class Toggle(Control):
         self,
         label=None,
         id=None,
+        ref=None,
         value=None,
         value_field=None,
         inline=None,
@@ -31,6 +32,7 @@ class Toggle(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,

--- a/pglet/toolbar.py
+++ b/pglet/toolbar.py
@@ -9,6 +9,7 @@ class Toolbar(Control):
     def __init__(
         self,
         id=None,
+        ref=None,
         inverted=None,
         items=None,
         overflow=None,
@@ -24,6 +25,7 @@ class Toolbar(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,
@@ -91,8 +93,8 @@ class Toolbar(Control):
 
 
 class Overflow(Control):
-    def __init__(self, id=None, items=None):
-        Control.__init__(self, id=id)
+    def __init__(self, id=None, ref=None, items=None):
+        Control.__init__(self, id=id, ref=ref)
 
         self.__items = []
         if items != None:
@@ -116,8 +118,8 @@ class Overflow(Control):
 
 
 class Far(Control):
-    def __init__(self, id=None, items=None):
-        Control.__init__(self, id=id)
+    def __init__(self, id=None, ref=None, items=None):
+        Control.__init__(self, id=id, ref=ref)
 
         self.__items = []
         if items != None:
@@ -144,6 +146,7 @@ class Item(Control):
     def __init__(
         self,
         id=None,
+        ref=None,
         text=None,
         secondary_text=None,
         url=None,
@@ -159,7 +162,9 @@ class Item(Control):
         disabled=None,
         data=None,
     ):
-        Control.__init__(self, id=id, visible=visible, disabled=disabled, data=data)
+        Control.__init__(
+            self, id=id, ref=ref, visible=visible, disabled=disabled, data=data
+        )
 
         self.text = text
         self.secondary_text = secondary_text

--- a/pglet/verticalbarchart.py
+++ b/pglet/verticalbarchart.py
@@ -17,6 +17,7 @@ class VerticalBarChart(Control):
     def __init__(
         self,
         id=None,
+        ref=None,
         legend=None,
         tooltips=None,
         bar_width=None,
@@ -38,6 +39,7 @@ class VerticalBarChart(Control):
         Control.__init__(
             self,
             id=id,
+            ref=ref,
             width=width,
             height=height,
             padding=padding,
@@ -162,8 +164,8 @@ class VerticalBarChart(Control):
 
 
 class Data(Control):
-    def __init__(self, id=None, points=None):
-        Control.__init__(self, id=id)
+    def __init__(self, id=None, ref=None, points=None):
+        Control.__init__(self, id=id, ref=ref)
 
         self.__points = []
         if points != None:
@@ -190,6 +192,7 @@ class Point(Control):
     def __init__(
         self,
         id=None,
+        ref=None,
         x=None,
         y=None,
         legend=None,
@@ -197,7 +200,7 @@ class Point(Control):
         x_tooltip=None,
         y_tooltip=None,
     ):
-        Control.__init__(self, id=id)
+        Control.__init__(self, id=id, ref=ref)
 
         self.x = x
         self.y = y

--- a/tests/test_iframe.py
+++ b/tests/test_iframe.py
@@ -101,6 +101,14 @@ def test_iframe_border_width():
     assert v == ""
 
 
+def test_iframe_border_width_mixed():
+    # list of values
+    c = IFrame(border_width=["1px", "2px", 1, 2])
+    v = c.border_width
+    assert isinstance(v, List)
+    assert len(v) == 4
+
+
 def test_iframe_border_radius():
     # list of values
     c = IFrame(border_radius=["1px", "2px", "1", "2"])


### PR DESCRIPTION
To access control propeties you need to have a refence to that control, so currently you first declare that control and then add it to a layout, for example:

```python
# controls that we need to access in the event handler
comments = Textbox(label="Comments", width="100%", multiline=True, auto_adjust_height=True, resizable=False)
is_public = Checkbox(label="Make public")

# event handler
def submit_click(e):
  # access control properties
  print(comments.value)
  print(is_public.value)

# layout
page.add(Stack(controls[
  comments,
  is_public,
  Button("Submit comment", on_click=submit_click)
]))
```

This PR introduces `Ref[ControlType]` that stores a refrence to a control object and allows keeping the entire layout in one place. The idea is similar to [React Refs](https://reactjs.org/docs/refs-and-the-dom.html). With `Ref`s the example above can be rewritten as:

```python
# controls that we need to access in the event handler
comments = Ref[Textbox]()
is_public = Ref[Checkbox]()

# event handler
def submit_click(e):
  # access control properties
  # using <reference>.current
  print(comments.current.value)
  print(is_public.current.value)

# layout
page.add(Stack(controls[
  Textbox(ref=comments, label="Comments", width="100%", multiline=True, auto_adjust_height=True, resizable=False),
  Checkbox(ref=is_public, label="Make public"),
  Button("Submit comment", on_click=submit_click)
]))
```

You create a refrence object as `Ref[<ControlType>]()` then add `ref=<reference>` argument to a call to control init method, to bind control and reference together, and, finally, use `<reference>.current` property to access the control:

```python
# declare reference to a Textbox
first_name = Ref[Textbox]()

# use the reference to access control properties
entered_text = first_name.current.value

# add control with a reference to a page
page.add(Textbox(ref=first_name, label="Enter some text"))
```