### PR TITLE
Housekeeping: Remove beartype warnings

### DIFF
--- a/examples/stack.py
+++ b/examples/stack.py
@@ -11,21 +11,19 @@ with pglet.page("horizontal-stack-wrapping") as page:
     page.horizontal_align = "stretch"
 
     def items(count):
-        items = []
-        for i in range(1, count + 1):
-            items.append(
-                Text(
-                    value=i,
-                    align="center",
-                    vertical_align="center",
-                    width=30,
-                    height=30,
-                    bgcolor="BlueMagenta10",
-                    color="white",
-                    padding=5,
-                )
+        return [
+            Text(
+                value=i + 1,
+                align="center",
+                vertical_align="center",
+                width=30,
+                height=30,
+                bgcolor="BlueMagenta10",
+                color="white",
+                padding=5,
             )
-        return items
+            for i in range(count)
+        ]
 
     def wrap_slider_change(e):
         print("wrap_slider_change", e)

--- a/pdm.lock
+++ b/pdm.lock
@@ -12,7 +12,7 @@ summary = "Classes Without Boilerplate"
 
 [[package]]
 name = "beartype"
-version = "0.10.0"
+version = "0.10.4"
 requires_python = ">=3.6.0"
 summary = "Unbearably fast runtime type checking in pure Python."
 
@@ -35,19 +35,19 @@ summary = "Distribution utilities"
 
 [[package]]
 name = "filelock"
-version = "3.4.2"
+version = "3.6.0"
 requires_python = ">=3.7"
 summary = "A platform independent file lock."
 
 [[package]]
 name = "identify"
-version = "2.4.9"
+version = "2.4.12"
 requires_python = ">=3.7"
 summary = "File identification library for Python"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.11.0"
+version = "4.11.3"
 requires_python = ">=3.7"
 summary = "Read metadata from Python packages"
 dependencies = [
@@ -76,7 +76,7 @@ dependencies = [
 
 [[package]]
 name = "platformdirs"
-version = "2.5.0"
+version = "2.5.1"
 requires_python = ">=3.7"
 summary = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 
@@ -118,8 +118,8 @@ summary = "Python parsing module"
 
 [[package]]
 name = "pytest"
-version = "7.0.1"
-requires_python = ">=3.6"
+version = "7.1.1"
+requires_python = ">=3.7"
 summary = "pytest: simple powerful testing with Python"
 dependencies = [
     "atomicwrites>=1.0; sys_platform == \"win32\"",
@@ -159,13 +159,13 @@ summary = "A lil' TOML parser"
 
 [[package]]
 name = "typing-extensions"
-version = "4.1.0"
+version = "4.1.1"
 requires_python = ">=3.6"
 summary = "Backported and Experimental Type Hints for Python 3.6+"
 
 [[package]]
 name = "virtualenv"
-version = "20.13.1"
+version = "20.13.4"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 summary = "Virtual Python Environment builder"
 dependencies = [
@@ -178,7 +178,7 @@ dependencies = [
 
 [[package]]
 name = "websocket-client"
-version = "1.2.3"
+version = "1.3.1"
 requires_python = ">=3.6"
 summary = "WebSocket client for Python with low level API options"
 
@@ -201,9 +201,9 @@ content_hash = "sha256:be80cde9d007abeb2c0d352d9a69fa5aefc29a1345919aebfd5685df9
     {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
     {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
 ]
-"beartype 0.10.0" = [
-    {file = "beartype-0.10.0-py3-none-any.whl", hash = "sha256:a1880ffd710378bbe571cc9780517d7a77373d907dadf4857be5a786c4d8b049"},
-    {file = "beartype-0.10.0.tar.gz", hash = "sha256:4dd7dd284000718a4517d982e65135dbc3931f2531982bbb682d84d932d70eba"},
+"beartype 0.10.4" = [
+    {file = "beartype-0.10.4-py3-none-any.whl", hash = "sha256:1a65453bc25b39979bf5ad65fe5e73350551282956456d828fb5783468649e3e"},
+    {file = "beartype-0.10.4.tar.gz", hash = "sha256:24ec69f6a7f4e6e97af403d08de270def3248518060327095d23b1c4df64bf2a"},
 ]
 "cfgv 3.3.1" = [
     {file = "cfgv-3.3.1-py2.py3-none-any.whl", hash = "sha256:c6a0883f3917a037485059700b9e75da2464e6c27051014ad85ba6aaa5884426"},
@@ -217,17 +217,17 @@ content_hash = "sha256:be80cde9d007abeb2c0d352d9a69fa5aefc29a1345919aebfd5685df9
     {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},
     {file = "distlib-0.3.4.zip", hash = "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"},
 ]
-"filelock 3.4.2" = [
-    {file = "filelock-3.4.2-py3-none-any.whl", hash = "sha256:cf0fc6a2f8d26bd900f19bf33915ca70ba4dd8c56903eeb14e1e7a2fd7590146"},
-    {file = "filelock-3.4.2.tar.gz", hash = "sha256:38b4f4c989f9d06d44524df1b24bd19e167d851f19b50bf3e3559952dddc5b80"},
+"filelock 3.6.0" = [
+    {file = "filelock-3.6.0-py3-none-any.whl", hash = "sha256:f8314284bfffbdcfa0ff3d7992b023d4c628ced6feb957351d4c48d059f56bc0"},
+    {file = "filelock-3.6.0.tar.gz", hash = "sha256:9cd540a9352e432c7246a48fe4e8712b10acb1df2ad1f30e8c070b82ae1fed85"},
 ]
-"identify 2.4.9" = [
-    {file = "identify-2.4.9-py2.py3-none-any.whl", hash = "sha256:bff7c4959d68510bc28b99d664b6a623e36c6eadc933f89a4e0a9ddff9b4fee4"},
-    {file = "identify-2.4.9.tar.gz", hash = "sha256:e926ae3b3dc142b6a7a9c65433eb14ccac751b724ee255f7c2ed3b5970d764fb"},
+"identify 2.4.12" = [
+    {file = "identify-2.4.12-py2.py3-none-any.whl", hash = "sha256:5f06b14366bd1facb88b00540a1de05b69b310cbc2654db3c7e07fa3a4339323"},
+    {file = "identify-2.4.12.tar.gz", hash = "sha256:3f3244a559290e7d3deb9e9adc7b33594c1bc85a9dd82e0f1be519bf12a1ec17"},
 ]
-"importlib-metadata 4.11.0" = [
-    {file = "importlib_metadata-4.11.0-py3-none-any.whl", hash = "sha256:6affcdb3aec542dd98df8211e730bba6c5f2bec8288d47bacacde898f548c9ad"},
-    {file = "importlib_metadata-4.11.0.tar.gz", hash = "sha256:9e5e553bbba1843cb4a00823014b907616be46ee503d2b9ba001d214a8da218f"},
+"importlib-metadata 4.11.3" = [
+    {file = "importlib_metadata-4.11.3-py3-none-any.whl", hash = "sha256:1208431ca90a8cca1a6b8af391bb53c1a2db74e5d1cef6ddced95d4b2062edc6"},
+    {file = "importlib_metadata-4.11.3.tar.gz", hash = "sha256:ea4c597ebf37142f827b8f39299579e31685c31d3a438b59f469406afd0f2539"},
 ]
 "iniconfig 1.1.1" = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -241,9 +241,9 @@ content_hash = "sha256:be80cde9d007abeb2c0d352d9a69fa5aefc29a1345919aebfd5685df9
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
-"platformdirs 2.5.0" = [
-    {file = "platformdirs-2.5.0-py3-none-any.whl", hash = "sha256:30671902352e97b1eafd74ade8e4a694782bd3471685e78c32d0fdfd3aa7e7bb"},
-    {file = "platformdirs-2.5.0.tar.gz", hash = "sha256:8ec11dfba28ecc0715eb5fb0147a87b1bf325f349f3da9aab2cd6b50b96b692b"},
+"platformdirs 2.5.1" = [
+    {file = "platformdirs-2.5.1-py3-none-any.whl", hash = "sha256:bcae7cab893c2d310a711b70b24efb93334febe65f8de776ee320b517471e227"},
+    {file = "platformdirs-2.5.1.tar.gz", hash = "sha256:7535e70dfa32e84d4b34996ea99c5e432fa29a708d0f4e394bbcb2a8faa4f16d"},
 ]
 "pluggy 1.0.0" = [
     {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
@@ -261,9 +261,9 @@ content_hash = "sha256:be80cde9d007abeb2c0d352d9a69fa5aefc29a1345919aebfd5685df9
     {file = "pyparsing-3.0.7-py3-none-any.whl", hash = "sha256:a6c06a88f252e6c322f65faf8f418b16213b51bdfaece0524c1c1bc30c63c484"},
     {file = "pyparsing-3.0.7.tar.gz", hash = "sha256:18ee9022775d270c55187733956460083db60b37d0d0fb357445f3094eed3eea"},
 ]
-"pytest 7.0.1" = [
-    {file = "pytest-7.0.1-py3-none-any.whl", hash = "sha256:9ce3ff477af913ecf6321fe337b93a2c0dcf2a0a1439c43f5452112c1e4280db"},
-    {file = "pytest-7.0.1.tar.gz", hash = "sha256:e30905a0c131d3d94b89624a1cc5afec3e0ba2fbdb151867d8e0ebd49850f171"},
+"pytest 7.1.1" = [
+    {file = "pytest-7.1.1-py3-none-any.whl", hash = "sha256:92f723789a8fdd7180b6b06483874feca4c48a5c76968e03bb3e7f806a1869ea"},
+    {file = "pytest-7.1.1.tar.gz", hash = "sha256:841132caef6b1ad17a9afde46dc4f6cfa59a05f9555aae5151f73bdf2820ca63"},
 ]
 "pyyaml 6.0" = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
@@ -312,17 +312,17 @@ content_hash = "sha256:be80cde9d007abeb2c0d352d9a69fa5aefc29a1345919aebfd5685df9
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
-"typing-extensions 4.1.0" = [
-    {file = "typing_extensions-4.1.0-py3-none-any.whl", hash = "sha256:c13180fbaa7cd97065a4915ceba012bdb31dc34743e63ddee16360161d358414"},
-    {file = "typing_extensions-4.1.0.tar.gz", hash = "sha256:ba97c5143e5bb067b57793c726dd857b1671d4b02ced273ca0538e71ff009095"},
+"typing-extensions 4.1.1" = [
+    {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
+    {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
 ]
-"virtualenv 20.13.1" = [
-    {file = "virtualenv-20.13.1-py2.py3-none-any.whl", hash = "sha256:45e1d053cad4cd453181ae877c4ffc053546ae99e7dd049b9ff1d9be7491abf7"},
-    {file = "virtualenv-20.13.1.tar.gz", hash = "sha256:e0621bcbf4160e4e1030f05065c8834b4e93f4fcc223255db2a823440aca9c14"},
+"virtualenv 20.13.4" = [
+    {file = "virtualenv-20.13.4-py2.py3-none-any.whl", hash = "sha256:c3e01300fb8495bc00ed70741f5271fc95fed067eb7106297be73d30879af60c"},
+    {file = "virtualenv-20.13.4.tar.gz", hash = "sha256:ce8901d3bbf3b90393498187f2d56797a8a452fb2d0d7efc6fd837554d6f679c"},
 ]
-"websocket-client 1.2.3" = [
-    {file = "websocket_client-1.2.3-py3-none-any.whl", hash = "sha256:2eed4cc58e4d65613ed6114af2f380f7910ff416fc8c46947f6e76b6815f56c0"},
-    {file = "websocket-client-1.2.3.tar.gz", hash = "sha256:1315816c0acc508997eb3ae03b9d3ff619c9d12d544c9a9b553704b1cc4f6af5"},
+"websocket-client 1.3.1" = [
+    {file = "websocket_client-1.3.1-py3-none-any.whl", hash = "sha256:074e2ed575e7c822fc0940d31c3ac9bb2b1142c303eafcf3e304e6ce035522e8"},
+    {file = "websocket-client-1.3.1.tar.gz", hash = "sha256:6278a75065395418283f887de7c3beafb3aa68dada5cacbe4b214e8d26da499b"},
 ]
 "zipp 3.7.0" = [
     {file = "zipp-3.7.0-py3-none-any.whl", hash = "sha256:b47250dd24f92b7dd6a0a8fc5244da14608f3ca90a5efcd37a3b1642fac9a375"},

--- a/pglet/combobox.py
+++ b/pglet/combobox.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Union
+from beartype.typing import List, Optional, Union
 
 from beartype import beartype
 

--- a/pglet/control.py
+++ b/pglet/control.py
@@ -1,7 +1,7 @@
 import datetime as dt
 import threading
 from difflib import SequenceMatcher
-from typing import List, Optional, Union
+from beartype.typing import List, Optional, Union
 
 from beartype import beartype
 

--- a/pglet/form.py
+++ b/pglet/form.py
@@ -5,14 +5,18 @@ import time
 from dataclasses import is_dataclass
 from functools import partial
 from typing import Any
-from typing import List
 from typing import Union
 
+from beartype.typing import List
+from pglet import choicegroup
+from pglet import combobox
+from pglet import dropdown
 from pglet.button import Button
 from pglet.checkbox import Checkbox
 from pglet.choicegroup import ChoiceGroup
 from pglet.combobox import ComboBox
 from pglet.control import Control
+from pglet.control_event import ControlEvent
 from pglet.datepicker import DatePicker
 from pglet.dropdown import Dropdown
 from pglet.message import Message
@@ -22,10 +26,6 @@ from pglet.stack import Stack
 from pglet.text import Text
 from pglet.textbox import Textbox
 from pglet.toggle import Toggle
-from pglet import choicegroup
-from pglet import combobox
-from pglet import dropdown
-from pglet.control_event import ControlEvent
 
 __all__ = ["Form"]
 

--- a/pglet/iframe.py
+++ b/pglet/iframe.py
@@ -1,8 +1,9 @@
-from typing import List
-
 from beartype import beartype
-
-from pglet.control import BorderColor, BorderRadius, BorderStyle, BorderWidth, Control
+from pglet.control import BorderColor
+from pglet.control import BorderRadius
+from pglet.control import BorderStyle
+from pglet.control import BorderWidth
+from pglet.control import Control
 
 
 class IFrame(Control):

--- a/pglet/image.py
+++ b/pglet/image.py
@@ -1,8 +1,11 @@
-from typing import List, Optional
+from typing import Optional
 
 from beartype import beartype
-
-from pglet.control import BorderColor, BorderRadius, BorderStyle, BorderWidth, Control
+from pglet.control import BorderColor
+from pglet.control import BorderRadius
+from pglet.control import BorderStyle
+from pglet.control import BorderWidth
+from pglet.control import Control
 
 try:
     from typing import Literal

--- a/pglet/page.py
+++ b/pglet/page.py
@@ -1,10 +1,10 @@
 import json
 import logging
 import threading
-from typing import List, Optional
 
 from beartype import beartype
-
+from beartype.typing import List
+from beartype.typing import Optional
 from pglet import constants
 from pglet.connection import Connection
 from pglet.control import Control

--- a/pglet/spinner.py
+++ b/pglet/spinner.py
@@ -1,4 +1,4 @@
-from beartype._decor.main import beartype
+from beartype import beartype
 
 from pglet.control import Control
 

--- a/pglet/stack.py
+++ b/pglet/stack.py
@@ -1,8 +1,11 @@
-from typing import List, Optional
+from typing import Optional
 
 from beartype import beartype
-
-from pglet.control import BorderColor, BorderRadius, BorderStyle, BorderWidth, Control
+from pglet.control import BorderColor
+from pglet.control import BorderRadius
+from pglet.control import BorderStyle
+from pglet.control import BorderWidth
+from pglet.control import Control
 
 try:
     from typing import Literal

--- a/pglet/text.py
+++ b/pglet/text.py
@@ -1,16 +1,13 @@
-from typing import List, Optional
+from typing import Optional
 
 from beartype import beartype
-
-from pglet.control import (
-    BorderColor,
-    BorderRadius,
-    BorderStyle,
-    BorderWidth,
-    Control,
-    TextAlign,
-    TextSize,
-)
+from pglet.control import BorderColor
+from pglet.control import BorderRadius
+from pglet.control import BorderStyle
+from pglet.control import BorderWidth
+from pglet.control import Control
+from pglet.control import TextAlign
+from pglet.control import TextSize
 
 try:
     from typing import Literal


### PR DESCRIPTION
This PR updates typing.List imports to not generate the red warnings on import.

Also one non-functional change to the stack example, could not help myself.